### PR TITLE
app-route: Clean logging and command line args

### DIFF
--- a/app-route/llm_model.py
+++ b/app-route/llm_model.py
@@ -63,7 +63,7 @@ class LLMModel:
             "ReAct_Agent"
         ]
 
-    def __init__(self, model: str, max_new_tokens: int = 256, temperature: float = 0.1, device: str = "cuda", api_key: str = None,vllm: bool = True, prompt_type: str = "cot"):
+    def __init__(self, model: str, max_new_tokens: int = 256, temperature: float = 0.1, device: str = "cuda", api_key: str = None, vllm: bool = True, prompt_type: str = "cot", num_gpus: int = 1):
         self.model_name = model
         self.max_new_tokens = max_new_tokens
         self.temperature = temperature
@@ -71,6 +71,7 @@ class LLMModel:
         self.api_key = api_key
         self.vllm = vllm
         self.prompt_type=prompt_type
+        self.num_gpus = num_gpus
         self.model = self._create_model()
 
     @staticmethod
@@ -116,7 +117,8 @@ class LLMModel:
                 model_name="Qwen/Qwen2.5-72B-Instruct-GPTQ-Int4",
                 max_new_tokens=self.max_new_tokens,
                 temperature=self.temperature,
-                device=self.device
+                device=self.device,
+                num_gpus=self.num_gpus
             )
         else:
             return QwenModel(
@@ -277,11 +279,12 @@ class Qwen_vllm_Model:
         The device for inference.
     """
 
-    def __init__(self, model_name, max_new_tokens, temperature, device="cuda", prompt_type="base"):
+    def __init__(self, model_name, max_new_tokens, temperature, device="cuda", prompt_type="base", num_gpus=1):
         self.model_name = model_name
         self.max_new_tokens = max_new_tokens
         self.temperature = temperature
         self.device = device
+        self.num_gpus = num_gpus
         self._load_model()
         self.prompt_type = prompt_type
         if prompt_type == "base":
@@ -304,8 +307,8 @@ class Qwen_vllm_Model:
             model=self.model_name,
             device=self.device,
             quantization="gptq",  # Enable GPTQ 4-bit loading
-            gpu_memory_utilization=0.9,
-            tensor_parallel_size=4
+            gpu_memory_utilization=0.95,
+            tensor_parallel_size=self.num_gpus,
         )
 
         self.sampling_params = SamplingParams(

--- a/app-route/main.py
+++ b/app-route/main.py
@@ -14,6 +14,7 @@ def parse_args():
                         help='The directory where all output files will be saved. The directory will be created if it does not exist.')
     parser.add_argument('--max_iteration', type=int, default=10, help='Choose maximum trials for a query')
     parser.add_argument('--vllm', type=int, default=1, choices=[0, 1], help='Enable vllm if set to 1')
+    parser.add_argument('--num_gpus', type=int, default=1, help='The number of GPUs to use for tensor parallelism (VLLM).')
     parser.add_argument('--benchmark_path', type=str, default='error_config.json', help='Where to save the generated benchmark relative to root_dir (or where to look for it).')
     parser.add_argument('--static_benchmark_generation', type=int, default=0, choices=[0, 1], help='If set to 1, generate static benchmark')
     parser.add_argument('--prompt_type', type=str, default="base", help='Path to the error configuration file')

--- a/app-route/main.py
+++ b/app-route/main.py
@@ -10,12 +10,12 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Benchmark Configuration")
     parser.add_argument('--llm_agent_type', type=str, default="ReAct_Agent",choices=["GPT-Agent","Qwen/Qwen2.5-72B-Instruct","ReAct_Agent"], help='Choose the LLM agent')#"GPT-Agent"
     parser.add_argument('--num_queries', type=int, default=1, help='Number of queries to generate for each type')
-    parser.add_argument('--root_dir', type=str, default="/home/ubuntu/netpress_benchmark/app-route", help='Directory to save output JSONL file')
+    parser.add_argument('--root_dir', type=str, default="/home/ubuntu/netpress_benchmark/app-route/result", 
+                        help='The directory where all output files will be saved. The directory will be created if it does not exist.')
     parser.add_argument('--max_iteration', type=int, default=10, help='Choose maximum trials for a query')
     parser.add_argument('--vllm', type=int, default=1, choices=[0, 1], help='Enable vllm if set to 1')
-    parser.add_argument('--static', type=int, default=1, choices=[0, 1], help='If set to 1, use static benchmark')
+    parser.add_argument('--benchmark_path', type=str, default='error_config.json', help='Where to save the generated benchmark relative to root_dir (or where to look for it).')
     parser.add_argument('--static_benchmark_generation', type=int, default=0, choices=[0, 1], help='If set to 1, generate static benchmark')
-    parser.add_argument('--agent_test', type=int, default=1, choices=[0, 1], help='If set to 1, run agent test')
     parser.add_argument('--prompt_type', type=str, default="base", help='Path to the error configuration file')
     parser.add_argument('--parallel', type=int, default=1, choices=[0, 1], help='If set to 1, run in parallel')
     return parser.parse_args()

--- a/app-route/safety_check.py
+++ b/app-route/safety_check.py
@@ -3,6 +3,9 @@ from mininet.log import lg
 def safety_check(commands):
     if commands is None:
         return True
+    if 'sudo' in commands:
+        lg.output("Command containing 'sudo' is not allowed.")
+        return False
     if 'tcpdump' in commands:
         lg.output("Command containing 'tcpdump' is not allowed.")
         return False

--- a/app-route/test_function.py
+++ b/app-route/test_function.py
@@ -23,6 +23,7 @@ def static_benchmark_run_modify(args):
     start_time_2 = datetime.now()
     # Get the unique process ID to distinguish between different instances
     unique_id = os.getpid()
+    original_root_dir = args.root_dir
     if args.parallel == 1:
         args.root_dir = os.path.join(args.root_dir)
         if args.llm_agent_type == "Qwen/Qwen2.5-72B-Instruct":
@@ -32,12 +33,12 @@ def static_benchmark_run_modify(args):
         else:      
             result_path = os.path.join(args.root_dir, args.prompt_type+"_GPT")
     else:
-        args.root_dir = os.path.join(args.root_dir, 'result', args.llm_agent_type, datetime.now().strftime("%Y%m%d-%H%M%S"))
+        args.root_dir = os.path.join(args.root_dir, args.llm_agent_type, datetime.now().strftime("%Y%m%d-%H%M%S"))
         result_path = args.root_dir
     os.makedirs(args.root_dir, exist_ok=True)
 
     # Generate or load the error configuration file
-    file_path = os.path.join(args.root_dir, 'error_config.json')
+    file_path = os.path.join(original_root_dir, args.benchmark_path)
     if args.static_benchmark_generation == 1 and args.parallel == 0:
         generate_config(file_path, num_errors_per_type=args.num_queries)
         print(f"Process {unique_id}: Using error configuration file: {file_path}")

--- a/app-route/test_function.py
+++ b/app-route/test_function.py
@@ -109,9 +109,9 @@ def static_benchmark_run_modify(args):
             # Execute LLM command
             if iter != 0:
 
-                lg.output(f"Machine: {machine}")
-                lg.output(f'{iter} iteration')
-                lg.output(f"Command: {commands}")
+                lg.output(f"Machine: {machine}\n")
+                lg.output(f'Iteration: {iter}\n')
+                lg.output(f"Command: {commands}\n")
 
                 if safety_check(commands):
                     try:
@@ -120,10 +120,10 @@ def static_benchmark_run_modify(args):
                         print("LLM command executed successfully")
 
                     except TimeoutError as te:
-                        lg.output(f"Timeout occurred while executing command on {machine}: {te}")
+                        lg.output(f"Timeout occurred while executing command on {machine}: {te}\n")
                     except Exception as e:
                         # Handle exceptions, log the error, and continue
-                        lg.output(f"Error occurred while executing command on {machine}: {e}")
+                        lg.output(f"Error occurred while executing command on {machine}: {e}\n")
 
             # Ping all hosts in the network
             start_time = datetime.now()
@@ -138,10 +138,10 @@ def static_benchmark_run_modify(args):
             
             # Read log file content
             if iter != 0:
-                log_content = f"Machine: {machine}\n" + f"Command: {commands}\n" + command_output + f"Pingall result: {pingall}\n"
+                log_content = f"Machine: {machine}\n" + f"Command: {commands}\n" + f"Command Output: \n{command_output}\n" + f"Pingall result:\n{pingall}\n"
             else:
-                log_content = f"Pingall result: {pingall}\n"
-            print("log_content: ", log_content)
+                log_content = f"Pingall result:\n{pingall}\n"
+            print(f"\n**LOG CONTENT**\n{log_content}")
 
             # Get LLM response
             attempt = 0
@@ -150,7 +150,7 @@ def static_benchmark_run_modify(args):
                 print(f"Attempt {attempt}: Calling LLM...")
                 try:
                     machine, commands = llm_model.model.predict(log_content, result_file_path, json_path)
-                    print(f"Generated LLM command: {machine} {commands}")
+                    print(f"Generated LLM command ([machine] [command]): {machine} {commands}")
                     break
                 except Exception as e:
                     print(f"Error while generating LLM command: {e}")

--- a/app-route/test_function.py
+++ b/app-route/test_function.py
@@ -52,7 +52,7 @@ def static_benchmark_run_modify(args):
     print(f"Number of queries: {len(queries)}")
 
     # Initialize the LLM model
-    llm_model = LLMModel(model=args.llm_agent_type, vllm=args.vllm, prompt_type=args.prompt_type)
+    llm_model = LLMModel(model=args.llm_agent_type, vllm=args.vllm, prompt_type=args.prompt_type, num_gpus=args.num_gpus)
     print("agenttype", args.llm_agent_type)
     if args.llm_agent_type == "Qwen/Qwen2.5-72B-Instruct":
         result_path = os.path.join(args.root_dir, args.prompt_type+"_Qwen")

--- a/app-route/test_function.py
+++ b/app-route/test_function.py
@@ -23,7 +23,6 @@ def static_benchmark_run_modify(args):
     start_time_2 = datetime.now()
     # Get the unique process ID to distinguish between different instances
     unique_id = os.getpid()
-    original_root_dir = args.root_dir
     if args.parallel == 1:
         args.root_dir = os.path.join(args.root_dir)
         if args.llm_agent_type == "Qwen/Qwen2.5-72B-Instruct":
@@ -38,7 +37,7 @@ def static_benchmark_run_modify(args):
     os.makedirs(args.root_dir, exist_ok=True)
 
     # Generate or load the error configuration file
-    file_path = os.path.join(original_root_dir, args.benchmark_path)
+    file_path = args.benchmark_path
     if args.static_benchmark_generation == 1 and args.parallel == 0:
         generate_config(file_path, num_errors_per_type=args.num_queries)
         print(f"Process {unique_id}: Using error configuration file: {file_path}")

--- a/experiments/run_app_route.sh
+++ b/experiments/run_app_route.sh
@@ -4,13 +4,15 @@ cd app-route  # Enter the application directory
 
 # Define common parameters
 NUM_QUERIES=1
-ROOT_DIR="/home/ubuntu/NetPress_benchmark/app-route"
+ROOT_DIR="/home/ubuntu/esw_benchmark/app-route/result"
+BENCHMARK_PATH="error_config.json"
 MAX_ITERATION=10
 FULL_TEST=1
 STATICGEN=1
 PROMPT_TYPE="base"
 # Define the model and parallel mode parameters
 MODEL="Qwen/Qwen2.5-72B-Instruct"  # Replace with the model you want to use
+NUM_GPUS=4  # Number of GPUs to use for tensor parallelism. Only relevant for models running locally with VLLM.
 PARALLEL=0  # Default to parallel execution. Set to 0 for single process.
 
 # Create a log file with a timestamp to avoid overwriting
@@ -36,7 +38,9 @@ run_benchmark() {
         --root_dir "$ROOT_DIR" \
         --max_iteration $MAX_ITERATION \
         --static_benchmark_generation $STATICGEN \
+        --benchmark_path "$BENCHMARK_PATH" \
         --prompt_type "$PROMPT_TYPE" \
+        --num_gpus $NUM_GPUS \
         --parallel "$PARALLEL" >> "$LOG_FILE" 2>&1 &
 }
 

--- a/experiments/run_app_route.sh
+++ b/experiments/run_app_route.sh
@@ -5,7 +5,7 @@ cd app-route  # Enter the application directory
 # Define common parameters
 NUM_QUERIES=1
 ROOT_DIR="/home/ubuntu/esw_benchmark/app-route/result"
-BENCHMARK_PATH="error_config.json"
+BENCHMARK_PATH="${ROOT_DIR}/error_config.json"
 MAX_ITERATION=10
 FULL_TEST=1
 STATICGEN=1


### PR DESCRIPTION
## Overview

Adjusted spacing issues/formatting of logging for clarity. Introduced some command line options to control where the benchmark data is saved and VLLM multi-GPU inference for locally run models like `Qwen2.5-72B` (single process). Minor bug fixes in safety/test code.

### Command Line Arguments

Changes here made related to saving output and VLLM.

- `--root_dir`: Changed this to refer to root directory of **results directory**
     - Ex: `app-route/result`
- `--num_gpus` **(new)**: Number of GPUs to use for tensor parallelism (if `VLLM` is enabled)
     - Should not be used with `--parallel` (no guarantees behavior)
- `--benchmark_path` **(new)**: Where to save the generated benchmark (or where to find it if reusing existing one).

### Testing/Safety

- Make retrieving the values of `"machine"` and `"command"` keys from LLM outputs not case sensitive (so `"mAchIne": "[machine]" is now valid too).
- Include `sudo` as a disallowed command in the safety check.